### PR TITLE
Better memory usage when using sheet.rows.each

### DIFF
--- a/lib/xlsx_sax_reader/rows_collection.rb
+++ b/lib/xlsx_sax_reader/rows_collection.rb
@@ -13,5 +13,8 @@ module XlsxSaxReader
       RowsCollectionParser.parse @index, @file_system, @shared_strings, &block
     end
 
+    def [](value)
+      to_a[value]
+    end
   end
 end

--- a/lib/xlsx_sax_reader/sheet.rb
+++ b/lib/xlsx_sax_reader/sheet.rb
@@ -11,7 +11,7 @@ module XlsxSaxReader
     end
 
     def rows
-      @rows ||= RowsCollection.new(@index, @file_system, @shared_strings).to_a
+      @rows ||= RowsCollection.new(@index, @file_system, @shared_strings)
     end
 
     def to_csv(path)

--- a/spec/sheet_spec.rb
+++ b/spec/sheet_spec.rb
@@ -20,6 +20,12 @@ describe Sheet do
     end
   end
 
+  it 'Rows collection' do
+    Workbook.open filename do |w|
+      w.sheets[0].rows.should be_an_instance_of RowsCollection
+    end
+  end
+
   it 'Rows content' do
     Workbook.open filename do |w|
       w.sheets[0].tap do |s|


### PR DESCRIPTION
When loading very large files (10Mb with 20000 rows) the memory usage was 1.7G+, using this patch I can iterate through each row individualy and avoid storing all rows in memory (@rows)
